### PR TITLE
Base.plugin(fooPlugin).plugin(barPlugin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ instance.options; // {foo: 'bar'}
 
 This example was extracted from [`@octokit/core`](https://github.com/gr2m/javascript-plugin-architecture-with-typescript-definitions). The implementation was made possible by help from [@karol-majewski](https://github.com/karol-majewski) and [@dragomirtitian](https://github.com/dragomirtitian).
 
+A final piece has been figured out by StackOverflow user "hackape": [Chaining static .plugin() class method to extend instance APIs multiple times](https://stackoverflow.com/a/58706699/206879).
+
 ## LICENSE
 
 [ISC](LICENSE)

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,10 @@ type ReturnTypeOf<T extends AnyFunction | AnyFunction[]> = T extends AnyFunction
 
 export class Base {
   static plugins: TestPlugin[] = [];
-  static plugin<T extends TestPlugin | TestPlugin[]>(plugin: T) {
+  static plugin<
+    S extends Constructor<any> & { plugins: any[] },
+    T extends TestPlugin | TestPlugin[]
+  >(this: S, plugin: T) {
     const currentPlugins = this.plugins;
 
     const BaseWithPlugins = class extends this {
@@ -40,12 +43,14 @@ export class Base {
     return BaseWithPlugins as typeof BaseWithPlugins & Constructor<Extension>;
   }
 
-  static defaults(defaults: Options) {
-    return class OctokitWithDefaults extends this {
-      constructor(options: Options = {}) {
-        super(Object.assign({}, defaults, options));
+  static defaults<S extends Constructor<any>>(this: S, defaults: Options) {
+    const OctokitWithDefaults = class extends this {
+      constructor(...args: any[]) {
+        super(Object.assign({}, defaults, args[0] || {}));
       }
     };
+
+    return OctokitWithDefaults;
   }
 
   constructor(options: Options = {}) {

--- a/test.ts
+++ b/test.ts
@@ -27,6 +27,12 @@ describe("Base", () => {
     expect(fooBarTest.foo()).toEqual("foo");
     expect(fooBarTest.bar()).toEqual("bar");
   });
+  it(".plugin(fooPlugin).plugin(barPlugin)", () => {
+    const FooBarTest = Base.plugin(fooPlugin).plugin(barPlugin);
+    const fooBarTest = new FooBarTest();
+    expect(fooBarTest.foo()).toEqual("foo");
+    expect(fooBarTest.bar()).toEqual("bar");
+  });
   it(".defaults({foo: 'bar'})", () => {
     const BaseWithDefaults = Base.defaults({ foo: "bar" });
     const defaultsTest = new BaseWithDefaults();


### PR DESCRIPTION
It looks like the current implementation does not allow for chainging of the static .plugin() method :/ I wonder if there is a way to fix this? The problem might be the same as in #4