### PR TITLE
test: plugin function with empty object return

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,8 @@ jobs:
     name: release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-node@v1
-        with:
-          node-version: "12.x"
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
       - run: npm ci
       - run: npm run build
       - run: npx semantic-release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
       - run: npm ci
       - run: npm test

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ import { Base } from "javascript-plugin-architecture-with-typescript-definitions
 
 function myFooPlugin(instance: Base) {
   return {
-    foo: () => "foo"
+    foo: () => "foo",
   };
 }
 
 function myBarPlugin(instance: Base) {
   return {
-    bar: () => "bar"
+    bar: () => "bar",
   };
 }
 
@@ -29,7 +29,7 @@ const FooTest = Base.plugin(myFooPlugin);
 const fooTest = new FooTest();
 fooTest.foo(); // has full TypeScript intellisense
 
-const FooBarTest = Base.plugin([myFooPlugin, myBarPlugin]);
+const FooBarTest = Base.plugin(myFooPlugin, myBarPlugin);
 const fooBarTest = new FooBarTest();
 fooBarTest.foo(); // has full TypeScript intellisense
 fooBarTest.bar(); // has full TypeScript intellisense

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,13 +33,11 @@ export class Base {
     S extends Constructor<any> & { plugins: any[] },
     T1 extends TestPlugin,
     T2 extends TestPlugin[]
-  >(this: S, plugin: T1, ...p2: T2) {
+  >(this: S, plugin1: T1, ...additionalPlugins: T2) {
     const currentPlugins = this.plugins;
     let newPlugins: (TestPlugin | undefined)[] = [
-      ...(plugin instanceof Array
-        ? (plugin as TestPlugin[])
-        : [plugin as TestPlugin]),
-      ...p2,
+      plugin1,
+      ...additionalPlugins,
     ];
 
     const BaseWithPlugins = class extends this {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,9 +13,9 @@ type Constructor<T> = new (...args: any[]) => T;
  * @author https://stackoverflow.com/users/2887218/jcalz
  * @see https://stackoverflow.com/a/50375286/10325032
  */
-type UnionToIntersection<Union> = (Union extends any
-  ? (argument: Union) => void
-  : never) extends (argument: infer Intersection) => void // tslint:disable-line: no-unused
+type UnionToIntersection<Union> = (
+  Union extends any ? (argument: Union) => void : never
+) extends (argument: infer Intersection) => void // tslint:disable-line: no-unused
   ? Intersection
   : never;
 
@@ -31,16 +31,25 @@ export class Base {
   static plugins: TestPlugin[] = [];
   static plugin<
     S extends Constructor<any> & { plugins: any[] },
-    T extends TestPlugin | TestPlugin[]
-  >(this: S, plugin: T) {
+    T1 extends TestPlugin,
+    T2 extends TestPlugin[]
+  >(this: S, plugin: T1, ...p2: T2) {
     const currentPlugins = this.plugins;
+    let newPlugins: (TestPlugin | undefined)[] = [
+      ...(plugin instanceof Array
+        ? (plugin as TestPlugin[])
+        : [plugin as TestPlugin]),
+      ...p2,
+    ];
 
     const BaseWithPlugins = class extends this {
-      static plugins = currentPlugins.concat(plugin);
+      static plugins = currentPlugins.concat(
+        newPlugins.filter((plugin) => !currentPlugins.includes(plugin))
+      );
     };
 
-    type Extension = ReturnTypeOf<T>;
-    return BaseWithPlugins as typeof BaseWithPlugins & Constructor<Extension>;
+    return BaseWithPlugins as typeof BaseWithPlugins &
+      Constructor<UnionToIntersection<ReturnTypeOf<T1> & ReturnTypeOf<T2>>>;
   }
 
   static defaults<S extends Constructor<any>>(this: S, defaults: Options) {
@@ -59,7 +68,7 @@ export class Base {
     // apply plugins
     // https://stackoverflow.com/a/16345172
     const classConstructor = this.constructor as typeof Base;
-    classConstructor.plugins.forEach(plugin => {
+    classConstructor.plugins.forEach((plugin) => {
       Object.assign(this, plugin(this, options));
     });
   }

--- a/test.ts
+++ b/test.ts
@@ -4,15 +4,18 @@ const fooPlugin = (test: Base) => {
   console.log("plugin evalutes");
 
   return {
-    foo: () => "foo"
+    foo: () => "foo",
   };
 };
 const barPlugin = (test: Base) => {
   console.log("plugin evalutes");
 
   return {
-    bar: () => "bar"
+    bar: () => "bar",
   };
+};
+const pluginWithEmptyObjectReturn = (test: Base) => {
+  return {};
 };
 
 describe("Base", () => {
@@ -21,8 +24,18 @@ describe("Base", () => {
     const fooTest = new FooTest();
     expect(fooTest.foo()).toEqual("foo");
   });
-  it(".plugin([fooPlugin, barPlugin])", () => {
-    const FooBarTest = Base.plugin([fooPlugin, barPlugin]);
+  it(".plugin(fooPlugin, barPlugin)", () => {
+    const FooBarTest = Base.plugin(fooPlugin, barPlugin);
+    const fooBarTest = new FooBarTest();
+    expect(fooBarTest.foo()).toEqual("foo");
+    expect(fooBarTest.bar()).toEqual("bar");
+  });
+  it(".plugin(fooPlugin, barPlugin, pluginWithVoidReturn)", () => {
+    const FooBarTest = Base.plugin(
+      fooPlugin,
+      barPlugin,
+      pluginWithEmptyObjectReturn
+    );
     const fooBarTest = new FooBarTest();
     expect(fooBarTest.foo()).toEqual("foo");
     expect(fooBarTest.bar()).toEqual("bar");
@@ -43,10 +56,10 @@ describe("Base", () => {
 
   it(".plugin().defaults()", () => {
     const BaseWithPluginAndDefaults = Base.plugin(fooPlugin).defaults({
-      baz: "daz"
+      baz: "daz",
     });
     const BaseWithDefaultsAndPlugin = Base.defaults({
-      baz: "daz"
+      baz: "daz",
     }).plugin(fooPlugin);
 
     const instance1 = new BaseWithPluginAndDefaults();


### PR DESCRIPTION
Follow up for https://github.com/octokit/rest.js/pull/1625

The test passes, but the TypeScript typeahead is not workin in VS Code for me

![Kapture 2020-03-02 at 11 15 11](https://user-images.githubusercontent.com/39992/75709235-22077880-5c77-11ea-8973-92771e28fd63.gif)

Here is the code from the gif

```ts
import { Base } from "./src"

function plugin1 (base: Base) {
  return {
    plugin1 () {}
  }
}

function plugin2 (base: Base) {
  return {
    plugin2 () {}
  }
}

function plugin3 (base: Base) {
  return {
    // plugin3 () {}
  }
}

const Test = Base.plugin([plugin1, plugin2, plugin3])
const test = new Test()

test.p
```

I hope it will be easier to get to the bottom of this with this reduced test case, compared to all the baggage that Octokit brings.

Besides fixing the problem, I wonder if anyone has an idea how to add a breaking test for this case?

ping @wolfy1339