### PR TITLE
feat: extend `Base` constructor options with plugins

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
-export declare namespace Base {
-  type Options = {
+export namespace Base {
+  interface Options {
     [key: string]: unknown;
-  };
+  }
 }
 
 declare type ApiExtension = {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -4,6 +4,7 @@ import { Base } from "./index.js";
 import { fooPlugin } from "./plugins/foo/index.js";
 import { barPlugin } from "./plugins/bar/index.js";
 import { voidPlugin } from "./plugins/void/index.js";
+import { withOptionsPlugin } from "./plugins/with-options";
 
 const base = new Base();
 
@@ -48,3 +49,8 @@ expectType<string>(baseWithVoidAndNonVoidPlugins.bar);
 
 // @ts-expect-error unknown properties cannot be used, see #31
 baseWithVoidAndNonVoidPlugins.unknown;
+
+const BaseWithOptionsPlugin = Base.plugin(withOptionsPlugin);
+const baseWithOptionsPlugin = new BaseWithOptionsPlugin();
+
+expectType<string>(baseWithOptionsPlugin.getFooOption());

--- a/plugins/with-options/index.d.ts
+++ b/plugins/with-options/index.d.ts
@@ -1,10 +1,17 @@
+// https://www.typescriptlang.org/docs/handbook/declaration-files/templates/module-plugin-d-ts.html
 import { Base } from "../..";
 
-// TODO: add "foo" to Base.Options type
+declare module "../.." {
+  namespace Base {
+    interface Options {
+      foo?: string;
+    }
+  }
+}
 
 export function withOptionsPlugin(
   base: Base,
   options: Base.Options
 ): {
-  getFooOption: () => Base.Options["foo"];
+  getFooOption: () => Required<Base.Options>["foo"];
 };

--- a/plugins/with-options/index.d.ts
+++ b/plugins/with-options/index.d.ts
@@ -1,0 +1,10 @@
+import { Base } from "../..";
+
+// TODO: add "foo" to Base.Options type
+
+export function withOptionsPlugin(
+  base: Base,
+  options: Base.Options
+): {
+  getFooOption: () => Base.Options["foo"];
+};

--- a/plugins/with-options/index.js
+++ b/plugins/with-options/index.js
@@ -5,7 +5,7 @@
 export function withOptionsPlugin(base, options) {
   return {
     getFooOption() {
-      return options.foo;
+      return options.foo || "my default";
     },
   };
 }

--- a/plugins/with-options/index.js
+++ b/plugins/with-options/index.js
@@ -1,0 +1,11 @@
+/**
+ * @param {import('../..').Base} base
+ * @param {import('../..').Base.Options} options
+ */
+export function withOptionsPlugin(base, options) {
+  return {
+    getFooOption() {
+      return options.foo;
+    },
+  };
+}


### PR DESCRIPTION
Given a plugin uses the constructor options

```js
/**
 * @param {import('../..').Base} base
 * @param {import('../..').Base.Options} options
 */
export function withOptionsPlugin(base, options) {
  return {
    getFooOption() {
      return options.foo;
    },
  };
}
```

We want the plugin to be able to extend `Base.Options` so that when doing

```js
import { Base } from "javascript-plugin-architecture-with-typescript-definitions";
import { withOptionsPlugin } from "plugin-with-options";

const Test = Base.plugin(withOptionsPlugin);

const test = new Test({});
```

The editor should suggest `foo` as a constructor option for `new Test({})`

### Bonus

Extending `Base.Options` globally is great. But it would be even better if it was possible that the `foo` option only in a constructor that has the plugin loaded:

```js
new Test({
  // should suggest `foo`
});
new Base({
  // should _not_ suggest `foo`
});
```
