### PR TITLE
Added defaultOptions and hardcoded two-level defaults nesting

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -26,16 +26,16 @@ declare type UnionToIntersection<Union> = (
 declare type AnyFunction = (...args: any) => any;
 declare type ReturnTypeOf<T extends AnyFunction | AnyFunction[]> =
   T extends AnyFunction
-    ? ReturnType<T>
-    : T extends AnyFunction[]
-    ? UnionToIntersection<Exclude<ReturnType<T[number]>, void>>
-    : never;
+  ? ReturnType<T>
+  : T extends AnyFunction[]
+  ? UnionToIntersection<Exclude<ReturnType<T[number]>, void>>
+  : never;
 
 type ConstructorRequiringVersion<Class, PredefinedOptions> =
   { defaultOptions: PredefinedOptions } & (
     PredefinedOptions extends { version: string }
-      ? { new <NowProvided>(options?: NowProvided): Class & { options: NowProvided & PredefinedOptions }; }
-      : { new <NowProvided>(options: Base.Options & NowProvided): Class & { options: NowProvided & PredefinedOptions }; }
+    ? { new <NowProvided>(options?: NowProvided): Class & { options: NowProvided & PredefinedOptions }; }
+    : { new <NowProvided>(options: Base.Options & NowProvided): Class & { options: NowProvided & PredefinedOptions }; }
   );
 
 export declare class Base<TOptions extends Base.Options = Base.Options> {
@@ -85,7 +85,7 @@ export declare class Base<TOptions extends Base.Options = Base.Options> {
    * @remarks
    * Ideally, we would want to make this infinitely recursive: allowing any number of 
    * .defaults({ ... }).defaults({ ... }).defaults({ ... }).defaults({ ... })...
-   * However, we don't see a clean way in today's TypeSript syntax to do so.
+   * However, we don't see a clean way in today's TypeScript syntax to do so.
    * We instead artificially limit accurate type inference to just three levels,
    * since real users are not likely to go past that.
    * @see https://github.com/gr2m/javascript-plugin-architecture-with-typescript-definitions/pull/57
@@ -108,4 +108,4 @@ export declare class Base<TOptions extends Base.Options = Base.Options> {
 
   constructor(options: TOptions);
 }
-export {};
+export { };

--- a/index.js
+++ b/index.js
@@ -14,13 +14,18 @@ export class Base {
       );
     };
   }
+
   static defaults(defaults) {
     return class extends this {
       constructor(...args) {
         super(Object.assign({}, defaults, args[0] || {}));
       }
+
+      static defaultOptions = defaults;
     };
   }
+
+  static defaultOptions = {};
 
   static plugins = [];
 }

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ export class Base {
         super(Object.assign({}, defaults, args[0] || {}));
       }
 
-      static defaultOptions = defaults;
+      static defaultOptions = { ...defaults, ...this.defaultOptions };
     };
   }
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -57,7 +57,7 @@ expectType<{
   defaultOne: string,
   defaultTwo: number,
   version: string,
-}>(BaseLevelTwo.defaultOptions);
+}>({ ...BaseLevelTwo.defaultOptions });
 
 // Because 'version' is already provided, this needs no argument
 new BaseLevelTwo();
@@ -88,7 +88,7 @@ expectType<{
   defaultTwo: number,
   defaultThree: string[],
   version: string,
-}>(BaseLevelThree.defaultOptions);
+}>({ ...BaseLevelThree.defaultOptions });
 
 // Because 'version' is already provided, this needs no argument
 new BaseLevelThree();

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -13,21 +13,105 @@ const base = new Base({
 // @ts-expect-error unknown properties cannot be used, see #31
 base.unknown;
 
-const BaseWithDefaults = Base.defaults({
+const BaseWithEmptyDefaults = Base.defaults({
   // there should be no required options
 });
 
-const FooBase = Base.plugin(fooPlugin).defaults({
-  default: "value",
+// 'version' is missing and should still be required
+// @ts-expect-error
+new BaseWithEmptyDefaults()
+
+// 'version' is missing and should still be required
+// @ts-expect-error
+new BaseWithEmptyDefaults({})
+
+const BaseLevelOne = Base.plugin(fooPlugin).defaults({
+  defaultOne: "value",
   version: "1.2.3",
 });
-const fooBase = new FooBase({
-  option: "value",
+
+// Because 'version' is already provided, this needs no argument
+new BaseLevelOne();
+new BaseLevelOne({});
+
+expectType<{
+  defaultOne: string,
+  version: string,
+}>(BaseLevelOne.defaultOptions);
+
+const baseLevelOne = new BaseLevelOne({
+  optionOne: "value",
 });
 
-expectType<string>(fooBase.options.default);
-expectType<string>(fooBase.options.option);
-expectType<string>(fooBase.foo);
+expectType<string>(baseLevelOne.options.defaultOne);
+expectType<string>(baseLevelOne.options.optionOne);
+expectType<string>(baseLevelOne.options.version);
+// @ts-expect-error unknown properties cannot be used, see #31
+baseLevelOne.unknown;
+
+const BaseLevelTwo = BaseLevelOne.defaults({
+  defaultTwo: 0,
+});
+
+expectType<{
+  defaultOne: string,
+  defaultTwo: number,
+  version: string,
+}>(BaseLevelTwo.defaultOptions);
+
+// Because 'version' is already provided, this needs no argument
+new BaseLevelTwo();
+new BaseLevelTwo({});
+
+// 'version' may be overriden, though it's not necessary
+new BaseLevelTwo({
+  version: 'new version',
+});
+
+const baseLevelTwo = new BaseLevelTwo({
+  optionTwo: true
+});
+
+expectType<number>(baseLevelTwo.options.defaultTwo);
+expectType<string>(baseLevelTwo.options.defaultOne);
+expectType<boolean>(baseLevelTwo.options.optionTwo);
+expectType<string>(baseLevelTwo.options.version);
+// @ts-expect-error unknown properties cannot be used, see #31
+baseLevelTwo.unknown;
+
+const BaseLevelThree = BaseLevelTwo.defaults({
+  defaultThree: ['a', 'b', 'c'],
+});
+
+expectType<{
+  defaultOne: string,
+  defaultTwo: number,
+  defaultThree: string[],
+  version: string,
+}>(BaseLevelThree.defaultOptions);
+
+// Because 'version' is already provided, this needs no argument
+new BaseLevelThree();
+new BaseLevelThree({});
+
+// Previous settings may be overriden, though it's not necessary
+new BaseLevelThree({
+  optionOne: '',
+  optionTwo: false,
+  version: 'new version',
+});
+
+const baseLevelThree = new BaseLevelThree({
+  optionThree: [0, 1, 2]
+});
+
+expectType<string>(baseLevelThree.options.defaultOne);
+expectType<number>(baseLevelThree.options.defaultTwo);
+expectType<string[]>(baseLevelThree.options.defaultThree);
+expectType<number[]>(baseLevelThree.options.optionThree);
+expectType<string>(baseLevelThree.options.version);
+// @ts-expect-error unknown properties cannot be used, see #31
+baseLevelThree.unknown;
 
 const BaseWithVoidPlugin = Base.plugin(voidPlugin);
 const baseWithVoidPlugin = new BaseWithVoidPlugin({
@@ -69,3 +153,4 @@ const baseWithOptionsPlugin = new BaseWithOptionsPlugin({
 });
 
 expectType<string>(baseWithOptionsPlugin.getFooOption());
+

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -33,8 +33,18 @@ test(".defaults({foo: 'bar'})", () => {
   const BaseWithDefaults = Base.defaults({ foo: "bar" });
   const defaultsTest = new BaseWithDefaults();
   const mergedOptionsTest = new BaseWithDefaults({ baz: "daz" });
+  assert.equal(BaseWithDefaults.defaultOptions, { foo: "bar" });
   assert.equal(defaultsTest.options, { foo: "bar" });
   assert.equal(mergedOptionsTest.options, { foo: "bar", baz: "daz" });
+});
+
+test(".defaults({foo: 'bar', baz: 'daz' })", () => {
+  const BaseWithDefaults = Base.defaults({ foo: "bar" }).defaults({ baz: "daz" });
+  const defaultsTest = new BaseWithDefaults();
+  const mergedOptionsTest = new BaseWithDefaults({ faz: "boo" });
+  assert.equal(BaseWithDefaults.defaultOptions, { foo: "bar", baz: "daz" });
+  assert.equal(defaultsTest.options, { foo: "bar", baz: "daz" });
+  assert.equal(mergedOptionsTest.options, { foo: "bar", baz: "daz", faz: "boo" });
 });
 
 test(".plugin().defaults()", () => {


### PR DESCRIPTION
Builds onto https://github.com/gr2m/javascript-plugin-architecture-with-typescript-definitions/pull/57 with the long-lived temporary solution @gr2m referenced in that PR thread of having a known finite level of nesting.

I did away with fancy conditional types to make sure the type system doesn't get bogged down computing them all for plugins with a few options. I can add them back if you have test cases that require more than just `version` being required?

The big return type of the `static defaults` in theory could be automated a little bit with a recursive type. However, we wouldn't be able to go infinitely deep, and again the code to get that to work would be a good bit longer and less readable than how it is now. :shrug: