### PR TITLE
feat: user-defined required constructor options

### DIFF
--- a/examples/required-options/README.md
+++ b/examples/required-options/README.md
@@ -1,0 +1,29 @@
+# required options Example
+
+`Base` has no required options by default, so the following code has no type errors.
+
+```js
+import { Base } from "javascript-plugin-architecture-with-typescript-definitions";
+
+const base1 = new Base();
+const base2 = new Base({});
+```
+
+But required options can be added by extending the `Base.Optiions` interface.
+
+```ts
+declare module "javascript-plugin-architecture-with-typescript-definitions" {
+  namespace Base {
+    interface Options {
+      myRequiredUserOption: string;
+    }
+  }
+}
+```
+
+With that extension, the same code will have type a type error
+
+```ts
+// TS Error: Property 'myRequiredUserOption' is missing in type '{}' but required in type 'Options'
+const base = new Base({});
+```

--- a/examples/required-options/README.md
+++ b/examples/required-options/README.md
@@ -21,7 +21,7 @@ declare module "javascript-plugin-architecture-with-typescript-definitions" {
 }
 ```
 
-With that extension, the same code will have type a type error
+With that extension, the same code will have a type error
 
 ```ts
 // TS Error: Property 'myRequiredUserOption' is missing in type '{}' but required in type 'Options'

--- a/examples/required-options/README.md
+++ b/examples/required-options/README.md
@@ -9,7 +9,7 @@ const base1 = new Base();
 const base2 = new Base({});
 ```
 
-But required options can be added by extending the `Base.Optiions` interface.
+But required options can be added by extending the `Base.Options` interface.
 
 ```ts
 declare module "javascript-plugin-architecture-with-typescript-definitions" {

--- a/examples/required-options/index.d.ts
+++ b/examples/required-options/index.d.ts
@@ -1,5 +1,4 @@
 import { Base } from "../../index.js";
-export { Base } from "../../index.js";
 
 declare module "../.." {
   namespace Base {

--- a/examples/required-options/index.d.ts
+++ b/examples/required-options/index.d.ts
@@ -1,0 +1,12 @@
+import { Base } from "../../index.js";
+export { Base } from "../../index.js";
+
+declare module "../.." {
+  namespace Base {
+    interface Options {
+      myRequiredUserOption: string;
+    }
+  }
+}
+
+export class MyBase extends Base {}

--- a/examples/required-options/index.js
+++ b/examples/required-options/index.js
@@ -1,0 +1,13 @@
+import { Base } from "../../index.js";
+
+/**
+ * @param {Base} base
+ * @param {Base.Options} options
+ */
+function pluginRequiringOption(base, options) {
+  if (!options.myRequiredUserOption) {
+    throw new Error('Required option "myRequiredUserOption" missing');
+  }
+}
+
+export const MyBase = Base.plugin(pluginRequiringOption);

--- a/examples/required-options/index.test-d.ts
+++ b/examples/required-options/index.test-d.ts
@@ -1,0 +1,11 @@
+import { MyBase } from "./index.js";
+
+// @ts-expect-error - An argument for 'options' was not provided
+new MyBase();
+
+// @ts-expect-error - Type '{}' is missing the following properties from type 'Options': myRequiredUserOption
+new MyBase({});
+
+new MyBase({
+  myRequiredUserOption: "",
+});

--- a/examples/required-options/index.test-d.ts
+++ b/examples/required-options/index.test-d.ts
@@ -9,3 +9,9 @@ new MyBase({});
 new MyBase({
   myRequiredUserOption: "",
 });
+
+const MyBaseWithDefaults = MyBase.defaults({
+  myRequiredUserOption: "",
+});
+
+new MyBaseWithDefaults();

--- a/examples/required-options/test.js
+++ b/examples/required-options/test.js
@@ -1,0 +1,18 @@
+import { test } from "uvu";
+import * as assert from "uvu/assert";
+
+import { MyBase } from "./index.js";
+
+test("new MyBase()", () => {
+  assert.throws(() => new MyBase());
+});
+
+test("new MyBase({})", () => {
+  assert.throws(() => new MyBase({}));
+});
+
+test('new MyBase({ myRequiredUserOption: ""})', () => {
+  assert.not.throws(() => new MyBase({ myRequiredUserOption: "" }));
+});
+
+test.run();

--- a/index.d.ts
+++ b/index.d.ts
@@ -50,7 +50,6 @@ type ConstructorRequiringVersion<Class extends ClassWithPlugins, PredefinedOptio
   defaultOptions: PredefinedOptions;
 } & {
   new <NowProvided>(...options: RequiredIfRemaining<PredefinedOptions, NowProvided>): Class & {
-    debugKeys: NonOptionalKeys<RemainingRequirements<PredefinedOptions>>;
     options: NowProvided & PredefinedOptions;
   };
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 export declare namespace Base {
-  interface Options {}
+  interface Options { }
 }
 
 declare type ApiExtension = {
@@ -23,10 +23,10 @@ declare type UnionToIntersection<Union> = (
 declare type AnyFunction = (...args: any) => any;
 declare type ReturnTypeOf<T extends AnyFunction | AnyFunction[]> =
   T extends AnyFunction
-    ? ReturnType<T>
-    : T extends AnyFunction[]
-    ? UnionToIntersection<Exclude<ReturnType<T[number]>, void>>
-    : never;
+  ? ReturnType<T>
+  : T extends AnyFunction[]
+  ? UnionToIntersection<Exclude<ReturnType<T[number]>, void>>
+  : never;
 
 type ClassWithPlugins = Constructor<any> & {
   plugins: Plugin[];
@@ -34,22 +34,23 @@ type ClassWithPlugins = Constructor<any> & {
 
 type RemainingRequirements<PredefinedOptions> =
   keyof PredefinedOptions extends never
-    ? Base.Options
-    : Omit<Base.Options, keyof PredefinedOptions>
+  ? Base.Options
+  : Omit<Base.Options, keyof PredefinedOptions>
 
 type NonOptionalKeys<Obj> = {
-  [K in keyof Obj]: {} extends Pick<Obj, K> ? never : K;
+  [K in keyof Obj]: {} extends Pick<Obj, K> ? undefined : K;
 }[keyof Obj];
 
-type RequiredIfRemaining<PredefinedOptions, NowProvided> = 
-  NonOptionalKeys<RemainingRequirements<PredefinedOptions>> extends never
-    ? [(Partial<Base.Options> & NowProvided)?]
-    : [Partial<Base.Options> & RemainingRequirements<PredefinedOptions> & NowProvided];
+type RequiredIfRemaining<PredefinedOptions, NowProvided> =
+  NonOptionalKeys<RemainingRequirements<PredefinedOptions>> extends undefined
+  ? [(Partial<Base.Options> & NowProvided)?]
+  : [Partial<Base.Options> & RemainingRequirements<PredefinedOptions> & NowProvided];
 
 type ConstructorRequiringVersion<Class extends ClassWithPlugins, PredefinedOptions> = {
   defaultOptions: PredefinedOptions;
 } & {
   new <NowProvided>(...options: RequiredIfRemaining<PredefinedOptions, NowProvided>): Class & {
+    debugKeys: NonOptionalKeys<RemainingRequirements<PredefinedOptions>>;
     options: NowProvided & PredefinedOptions;
   };
 };
@@ -79,9 +80,9 @@ export declare class Base<TOptions extends Base.Options = Base.Options> {
   static plugin<
     Class extends ClassWithPlugins,
     Plugins extends [Plugin, ...Plugin[]],
-  >(
-    this: Class,
-    ...plugins: Plugins,
+    >(
+      this: Class,
+      ...plugins: Plugins,
   ): Class & {
     plugins: [...Class['plugins'], ...Plugins];
   } & Constructor<UnionToIntersection<ReturnTypeOf<Plugins>>>;
@@ -135,4 +136,4 @@ export declare class Base<TOptions extends Base.Options = Base.Options> {
 
   constructor(options: TOptions);
 }
-export {};
+export { };

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -6,37 +6,45 @@ import { barPlugin } from "./plugins/bar/index.js";
 import { voidPlugin } from "./plugins/void/index.js";
 import { withOptionsPlugin } from "./plugins/with-options";
 
-const base = new Base({
-  version: "1.2.3",
+declare module "./index.js" {
+  namespace Base {
+    interface Options {
+      required: string;
+    }
+  }
+}
+
+const baseSatisfied = new Base({
+  required: "1.2.3",
 });
 
 // @ts-expect-error unknown properties cannot be used, see #31
-base.unknown;
+baseSatisfied.unknown;
 
 const BaseWithEmptyDefaults = Base.defaults({
   // there should be no required options
 });
 
-// 'version' is missing and should still be required
+// 'required' is missing and should still be required
 // @ts-expect-error
 new BaseWithEmptyDefaults();
 
-// 'version' is missing and should still be required
+// 'required' is missing and should still be required
 // @ts-expect-error
 new BaseWithEmptyDefaults({});
 
 const BaseLevelOne = Base.plugin(fooPlugin).defaults({
   defaultOne: "value",
-  version: "1.2.3",
+  required: "1.2.3",
 });
 
-// Because 'version' is already provided, this needs no argument
+// Because 'required' is already provided, this needs no argument
 new BaseLevelOne();
 new BaseLevelOne({});
 
 expectType<{
   defaultOne: string;
-  version: string;
+  required: string;
 }>(BaseLevelOne.defaultOptions);
 
 const baseLevelOne = new BaseLevelOne({
@@ -45,7 +53,7 @@ const baseLevelOne = new BaseLevelOne({
 
 expectType<string>(baseLevelOne.options.defaultOne);
 expectType<string>(baseLevelOne.options.optionOne);
-expectType<string>(baseLevelOne.options.version);
+expectType<string>(baseLevelOne.options.required);
 // @ts-expect-error unknown properties cannot be used, see #31
 baseLevelOne.unknown;
 
@@ -56,16 +64,16 @@ const BaseLevelTwo = BaseLevelOne.defaults({
 expectType<{
   defaultOne: string;
   defaultTwo: number;
-  version: string;
+  required: string;
 }>({ ...BaseLevelTwo.defaultOptions });
 
-// Because 'version' is already provided, this needs no argument
+// Because 'required' is already provided, this needs no argument
 new BaseLevelTwo();
 new BaseLevelTwo({});
 
-// 'version' may be overriden, though it's not necessary
+// 'required' may be overriden, though it's not necessary
 new BaseLevelTwo({
-  version: "new version",
+  required: "new required",
 });
 
 const baseLevelTwo = new BaseLevelTwo({
@@ -75,7 +83,7 @@ const baseLevelTwo = new BaseLevelTwo({
 expectType<number>(baseLevelTwo.options.defaultTwo);
 expectType<string>(baseLevelTwo.options.defaultOne);
 expectType<boolean>(baseLevelTwo.options.optionTwo);
-expectType<string>(baseLevelTwo.options.version);
+expectType<string>(baseLevelTwo.options.required);
 // @ts-expect-error unknown properties cannot be used, see #31
 baseLevelTwo.unknown;
 
@@ -87,10 +95,10 @@ expectType<{
   defaultOne: string;
   defaultTwo: number;
   defaultThree: string[];
-  version: string;
+  required: string;
 }>({ ...BaseLevelThree.defaultOptions });
 
-// Because 'version' is already provided, this needs no argument
+// Because 'required' is already provided, this needs no argument
 new BaseLevelThree();
 new BaseLevelThree({});
 
@@ -98,7 +106,7 @@ new BaseLevelThree({});
 new BaseLevelThree({
   optionOne: "",
   optionTwo: false,
-  version: "new version",
+  required: "new required",
 });
 
 const baseLevelThree = new BaseLevelThree({
@@ -109,13 +117,13 @@ expectType<string>(baseLevelThree.options.defaultOne);
 expectType<number>(baseLevelThree.options.defaultTwo);
 expectType<string[]>(baseLevelThree.options.defaultThree);
 expectType<number[]>(baseLevelThree.options.optionThree);
-expectType<string>(baseLevelThree.options.version);
+expectType<string>(baseLevelThree.options.required);
 // @ts-expect-error unknown properties cannot be used, see #31
 baseLevelThree.unknown;
 
 const BaseWithVoidPlugin = Base.plugin(voidPlugin);
 const baseWithVoidPlugin = new BaseWithVoidPlugin({
-  version: "1.2.3",
+  required: "1.2.3",
 });
 
 // @ts-expect-error unknown properties cannot be used, see #31
@@ -123,7 +131,7 @@ baseWithVoidPlugin.unknown;
 
 const BaseWithFooAndBarPlugins = Base.plugin(barPlugin, fooPlugin);
 const baseWithFooAndBarPlugins = new BaseWithFooAndBarPlugins({
-  version: "1.2.3",
+  required: "1.2.3",
 });
 
 expectType<string>(baseWithFooAndBarPlugins.foo);
@@ -138,7 +146,7 @@ const BaseWithVoidAndNonVoidPlugins = Base.plugin(
   fooPlugin
 );
 const baseWithVoidAndNonVoidPlugins = new BaseWithVoidAndNonVoidPlugins({
-  version: "1.2.3",
+  required: "1.2.3",
 });
 
 expectType<string>(baseWithVoidAndNonVoidPlugins.foo);
@@ -149,7 +157,7 @@ baseWithVoidAndNonVoidPlugins.unknown;
 
 const BaseWithOptionsPlugin = Base.plugin(withOptionsPlugin);
 const baseWithOptionsPlugin = new BaseWithOptionsPlugin({
-  version: "1.2.3",
+  required: "1.2.3",
 });
 
 expectType<string>(baseWithOptionsPlugin.getFooOption());
@@ -158,7 +166,7 @@ expectType<string>(baseWithOptionsPlugin.getFooOption());
 const BaseLevelFour = BaseLevelThree.defaults({ defaultFour: 4 });
 
 expectType<{
-  version: string;
+  required: string;
   defaultOne: string;
   defaultTwo: number;
   defaultThree: string[];
@@ -170,14 +178,14 @@ const baseLevelFour = new BaseLevelFour();
 // See the node on static defaults in index.d.ts for why defaultFour is missing
 // .options from .defaults() is only supported until a depth of 4
 expectType<{
-  version: string;
+  required: string;
   defaultOne: string;
   defaultTwo: number;
   defaultThree: string[];
 }>({ ...baseLevelFour.options });
 
 expectType<{
-  version: string;
+  required: string;
   defaultOne: string;
   defaultTwo: number;
   defaultThree: string[];
@@ -195,7 +203,7 @@ const BaseWithChainedDefaultsAndPlugins = Base.defaults({
 
 const baseWithChainedDefaultsAndPlugins = new BaseWithChainedDefaultsAndPlugins(
   {
-    version: "1.2.3",
+    required: "1.2.3",
   }
 );
 
@@ -221,7 +229,7 @@ expectType<{
 
 const baseWithManyChainedDefaultsAndPlugins =
   new BaseWithManyChainedDefaultsAndPlugins({
-    version: "1.2.3",
+    required: "1.2.3",
     foo: "bar",
   });
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -19,11 +19,11 @@ const BaseWithEmptyDefaults = Base.defaults({
 
 // 'version' is missing and should still be required
 // @ts-expect-error
-new BaseWithEmptyDefaults()
+new BaseWithEmptyDefaults();
 
 // 'version' is missing and should still be required
 // @ts-expect-error
-new BaseWithEmptyDefaults({})
+new BaseWithEmptyDefaults({});
 
 const BaseLevelOne = Base.plugin(fooPlugin).defaults({
   defaultOne: "value",
@@ -35,8 +35,8 @@ new BaseLevelOne();
 new BaseLevelOne({});
 
 expectType<{
-  defaultOne: string,
-  version: string,
+  defaultOne: string;
+  version: string;
 }>(BaseLevelOne.defaultOptions);
 
 const baseLevelOne = new BaseLevelOne({
@@ -54,9 +54,9 @@ const BaseLevelTwo = BaseLevelOne.defaults({
 });
 
 expectType<{
-  defaultOne: string,
-  defaultTwo: number,
-  version: string,
+  defaultOne: string;
+  defaultTwo: number;
+  version: string;
 }>({ ...BaseLevelTwo.defaultOptions });
 
 // Because 'version' is already provided, this needs no argument
@@ -65,11 +65,11 @@ new BaseLevelTwo({});
 
 // 'version' may be overriden, though it's not necessary
 new BaseLevelTwo({
-  version: 'new version',
+  version: "new version",
 });
 
 const baseLevelTwo = new BaseLevelTwo({
-  optionTwo: true
+  optionTwo: true,
 });
 
 expectType<number>(baseLevelTwo.options.defaultTwo);
@@ -80,14 +80,14 @@ expectType<string>(baseLevelTwo.options.version);
 baseLevelTwo.unknown;
 
 const BaseLevelThree = BaseLevelTwo.defaults({
-  defaultThree: ['a', 'b', 'c'],
+  defaultThree: ["a", "b", "c"],
 });
 
 expectType<{
-  defaultOne: string,
-  defaultTwo: number,
-  defaultThree: string[],
-  version: string,
+  defaultOne: string;
+  defaultTwo: number;
+  defaultThree: string[];
+  version: string;
 }>({ ...BaseLevelThree.defaultOptions });
 
 // Because 'version' is already provided, this needs no argument
@@ -96,13 +96,13 @@ new BaseLevelThree({});
 
 // Previous settings may be overriden, though it's not necessary
 new BaseLevelThree({
-  optionOne: '',
+  optionOne: "",
   optionTwo: false,
-  version: 'new version',
+  version: "new version",
 });
 
 const baseLevelThree = new BaseLevelThree({
-  optionThree: [0, 1, 2]
+  optionThree: [0, 1, 2],
 });
 
 expectType<string>(baseLevelThree.options.defaultOne);
@@ -185,19 +185,19 @@ expectType<{
   // @ts-expect-error - .options from .defaults() is only supported until a depth of 4
 }>({ ...baseLevelFour.options });
 
-const BaseWithChainedDefaultsAndPlugins = Base
-  .defaults({
-    defaultOne: "value",
-  })
+const BaseWithChainedDefaultsAndPlugins = Base.defaults({
+  defaultOne: "value",
+})
   .plugin(fooPlugin)
   .defaults({
     defaultTwo: 0,
   });
 
-const baseWithChainedDefaultsAndPlugins =
-  new BaseWithChainedDefaultsAndPlugins({
+const baseWithChainedDefaultsAndPlugins = new BaseWithChainedDefaultsAndPlugins(
+  {
     version: "1.2.3",
-  });
+  }
+);
 
 expectType<string>(baseWithChainedDefaultsAndPlugins.foo);
 

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
   "types": "./index.d.ts",
   "scripts": {
     "test": "npm run -s test:code && npm run -s test:typescript && npm run -s test:coverage",
-    "test:code": "c8 node test.js",
+    "test:code": "c8 uvu . '^(examples/.*/)?test.js$'",
     "test:coverage": "c8 check-coverage",
-    "test:typescript": "tsd"
+    "test:typescript": "tsd && tsd examples/*"
   },
   "repository": "github:gr2m/javascript-plugin-architecture-with-typescript-definitions",
   "keywords": [


### PR DESCRIPTION
closes #60

### TODOs

- [x] create `examples/required-options` folder with a README, code & tests that implements and tests a user-defined required constructor options
- [x] adapt `npm test` to run all code & type tests from both the root folder
- [x] remove the hard-coded `version` required option from `Base` and make it dynamic based on user-defined options instead 
- [x] update tests in `/index.d-test.ts` that test for the required `version` option and move them to `examples/required-options/index.test-d.ts` instead