### PR TITLE
feat: make `Base.plugin()` accept an array instead of multiple arguments, and change APIs from `Base.plugin()` / `Base.defaults()` / `Base.defaultOptions` to `Base.withPlugins()` / `Base.withDefaults()` / `Base.defaults`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ function myBarPlugin(instance: Base) {
   };
 }
 
-const FooTest = Base.plugin(myFooPlugin);
+const FooTest = Base.plugin([myFooPlugin]);
 const fooTest = new FooTest();
 fooTest.foo(); // has full TypeScript intellisense
 
-const FooBarTest = Base.plugin(myFooPlugin, myBarPlugin);
+const FooBarTest = Base.plugin([myFooPlugin, myBarPlugin]);
 const fooBarTest = new FooBarTest();
 fooBarTest.foo(); // has full TypeScript intellisense
 fooBarTest.bar(); // has full TypeScript intellisense

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 [![@latest](https://img.shields.io/npm/v/javascript-plugin-architecture-with-typescript-definitions.svg)](https://www.npmjs.com/package/javascript-plugin-architecture-with-typescript-definitions)
 [![Build Status](https://github.com/gr2m/javascript-plugin-architecture-with-typescript-definitions/workflows/Test/badge.svg)](https://github.com/gr2m/javascript-plugin-architecture-with-typescript-definitions/actions/workflows/test.yml)
 
-The goal of this repository is to provide a template of a simple plugin Architecture which allows plugins to created and authored as separate npm modules and shared as official or 3rd party plugins.
+The goal of this repository is to provide a template of a simple plugin Architecture which allows plugins to be created and authored as separate npm modules and shared as official or 3rd party plugins. It also permits the plugins to extend the types for the constructor options.
 
 ## Usage
 
-[Try it in TypeScript's playground editor](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAbzgIQIYGcCmcC+cBmUEIcARAFaoBuGAxlMGDALRgA2ArgObAB2zqKLQAWwGJlowOUTMwDuY4cxgBPMJnT1GLACaZ8fMcAi90pANwAoS-g69Jx3nBAqAYhAgAFTj14AKPnQYVHtMAC4UDEwASkRLODgZKSgnBHiEgg8Iv1iAXgA+MnwPUgAadJwrHGtbexhHZxU0KG9uPgDTYNCItCxYtISk6VT0hIAjQWy8wtIJqDKKqpq7BxM4DCxYAGUYBl4uP3QOMfIJGAigva5+6staEyC4dwgAFQ14XMisADp2Nv8XM9Wr5olZ7p1Mq93nBPrxMHInh43kEclYNphtrs+AdilCgt9cTlQdZwY9ns1kR8vphfj52oCPMC+KVGs0mbxiaT4LiKdDYfDERBeSjiejMVc-DzBJSCR4iWj0JsYDsJVKoDK5vKgA)
+[Try it in TypeScript's playground editor](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAbzgIQIYGcCmcC+cBmUEIcARAFaoBuGAxlMGDALRgA2ArgObAB2zqKLQAWwGJlowOUTMwDuY4cxgBPMJnT1GLACaZ8fMcAi90pANwAoS-g69Jx3nBAqAYhAgAFTj14AKPnQYVHtMAC4UDEwASkRLODgZKSgnBHiEgg8Iv1iAXgA+MnwPUgAadJwrHGtbexhHZxU0KG9uPgDTYNCItCxYtISk6VT0hIAjQWy8wtIJqDKKqpq7BxM4DCxYAGUYBl4uP3QOMfIJGAigva5+6staEyC4dwgAFQ14XMisADoFGGFWr50H4ANouZ6AvgAXWiVnunUyr3ecE+vEwcieHjeQRyVg2mG2uz4B2KSKC31JOVh1nhj2ezWxHy+mF+ikhplB4I87NKjWa7JhcIe8FJDORqPRmIgYpx1PxhKuflFgkZFI8VLx6E2MB2iuVUFVcw1QA)
 
 ```ts
 import { Base } from "javascript-plugin-architecture-with-typescript-definitions";
@@ -26,31 +26,56 @@ function myBarPlugin(instance: Base) {
   };
 }
 
-const FooTest = Base.plugin([myFooPlugin]);
+const FooTest = Base.withPlugins([myFooPlugin]);
 const fooTest = new FooTest();
 fooTest.foo(); // has full TypeScript intellisense
 
-const FooBarTest = Base.plugin([myFooPlugin, myBarPlugin]);
+const FooBarTest = Base.withPlugins([myFooPlugin, myBarPlugin]);
 const fooBarTest = new FooBarTest();
 fooBarTest.foo(); // has full TypeScript intellisense
 fooBarTest.bar(); // has full TypeScript intellisense
 ```
 
-The constructor accepts an optional `options` object which is passed to the plugins as second argument and stored in `instance.options`. Default options can be set using `Base.defaults(options)`
+The constructor accepts an optional `options` object which is passed to the plugins as second argument and stored in `instance.options`. Default options can be set using `Base.withDefaults(options)`.
 
 ```js
-const BaseWithOptions = Base.defaults({ foo: "bar" });
+const BaseWithOptions = Base.withDefaults({ foo: "bar" });
 const instance = new BaseWithOptions();
 instance.options; // {foo: 'bar'}
 ```
 
+Note that in for TypeScript to recognize the new option, you have to extend the `Base.Option` intererface.
+
+```ts
+declare module "javascript-plugin-architecture-with-typescript-definitions" {
+  namespace Base {
+    interface Options {
+      foo: string;
+    }
+  }
+}
+```
+
+See also the [`required-options` example](examples/required-options).
+
+The `Base` class also has two static properties
+
+- `.defaults`: the default options for all instances
+- `.plugins`: the list of plugins applied to all instances
+
+When creating a new class with `.withPlugins()` and `.defaults()`, the static properties of the returned class are set accordingly.
+
+```js
+const MyBase = Base.withDefaults({ foo: "bar" });
+```
+
 ### Defaults
 
-TypeScript will not complain when chaining `.defaults()` calls endlessly: the static `.defaultOptions` property will be set correctly. However, when instantiating from a class with 4+ chained `.defaults()` calls, then only the defaults from the first 3 calls are supported. See [#57](https://github.com/gr2m/javascript-plugin-architecture-with-typescript-definitions/pull/57) for details.
+TypeScript will not complain when chaining `.withDefaults()` calls endlessly: the static `.defaults` property will be set correctly. However, when instantiating from a class with 4+ chained `.withDefaults()` calls, then only the defaults from the first 3 calls are supported. See [#57](https://github.com/gr2m/javascript-plugin-architecture-with-typescript-definitions/pull/57) for details.
 
 ## Credit
 
-This plugin architecture was extracted from [`@octokit/core`](https://github.com/octokit/core.js). The implementation was made possible by help from [@karol-majewski](https://github.com/karol-majewski), [@dragomirtitian](https://github.com/dragomirtitian), and [StackOverflow user "hackape"](https://stackoverflow.com/a/58706699/206879).
+This plugin architecture was extracted from [`@octokit/core`](https://github.com/octokit/core.js). The implementation was made possible by help from [@karol-majewski](https://github.com/karol-majewski), [@dragomirtitian](https://github.com/dragomirtitian), [StackOverflow user "hackape"](https://stackoverflow.com/a/58706699/206879), and [@JoshuaKGoldberg](https://github.com/JoshuaKGoldberg).
 
 ## LICENSE
 

--- a/examples/required-options/index.js
+++ b/examples/required-options/index.js
@@ -10,4 +10,4 @@ function pluginRequiringOption(base, options) {
   }
 }
 
-export const MyBase = Base.plugin(pluginRequiringOption);
+export const MyBase = Base.withPlugins([pluginRequiringOption]);

--- a/examples/required-options/index.test-d.ts
+++ b/examples/required-options/index.test-d.ts
@@ -10,7 +10,7 @@ new MyBase({
   myRequiredUserOption: "",
 });
 
-const MyBaseWithDefaults = MyBase.defaults({
+const MyBaseWithDefaults = MyBase.withDefaults({
   myRequiredUserOption: "",
 });
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -91,7 +91,7 @@ export declare class Base<TOptions extends Base.Options = Base.Options> {
     Plugins extends [Plugin, ...Plugin[]]
   >(
     this: Class,
-    ...plugins: Plugins
+    plugins: Plugins
   ): Class & {
     plugins: [...Class["plugins"], ...Plugins];
   } & Constructor<UnionToIntersection<ReturnTypeOf<Plugins>>>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ export declare namespace Base {
 declare type ApiExtension = {
   [key: string]: unknown;
 };
-declare type Plugin = (
+export declare type Plugin = (
   instance: Base,
   options: Base.Options
 ) => ApiExtension | void;

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ export class Base {
     });
   }
 
-  static plugin(newPlugins) {
+  static withPlugins(newPlugins) {
     const currentPlugins = this.plugins;
     return class extends this {
       static plugins = currentPlugins.concat(
@@ -15,7 +15,7 @@ export class Base {
     };
   }
 
-  static defaults(defaults) {
+  static withDefaults(defaults) {
     return class extends this {
       constructor(options) {
         super({
@@ -24,11 +24,10 @@ export class Base {
         });
       }
 
-      static defaultOptions = { ...defaults, ...this.defaultOptions };
+      static defaults = { ...defaults, ...this.defaults };
     };
   }
 
-  static defaultOptions = {};
-
   static plugins = [];
+  static defaults = {};
 }

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ export class Base {
     });
   }
 
-  static plugin(...newPlugins) {
+  static plugin(newPlugins) {
     const currentPlugins = this.plugins;
     return class extends this {
       static plugins = currentPlugins.concat(

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -21,7 +21,7 @@ const baseSatisfied = new Base({
 // @ts-expect-error unknown properties cannot be used, see #31
 baseSatisfied.unknown;
 
-const BaseWithEmptyDefaults = Base.defaults({
+const BaseWithEmptyDefaults = Base.withDefaults({
   // there should be no required options
 });
 
@@ -33,7 +33,7 @@ new BaseWithEmptyDefaults();
 // @ts-expect-error
 new BaseWithEmptyDefaults({});
 
-const BaseLevelOne = Base.plugin([fooPlugin]).defaults({
+const BaseLevelOne = Base.withPlugins([fooPlugin]).withDefaults({
   defaultOne: "value",
   required: "1.2.3",
 });
@@ -45,7 +45,7 @@ new BaseLevelOne({});
 expectType<{
   defaultOne: string;
   required: string;
-}>(BaseLevelOne.defaultOptions);
+}>(BaseLevelOne.defaults);
 
 const baseLevelOne = new BaseLevelOne({
   optionOne: "value",
@@ -57,7 +57,7 @@ expectType<string>(baseLevelOne.options.required);
 // @ts-expect-error unknown properties cannot be used, see #31
 baseLevelOne.unknown;
 
-const BaseLevelTwo = BaseLevelOne.defaults({
+const BaseLevelTwo = BaseLevelOne.withDefaults({
   defaultTwo: 0,
 });
 
@@ -65,7 +65,7 @@ expectType<{
   defaultOne: string;
   defaultTwo: number;
   required: string;
-}>({ ...BaseLevelTwo.defaultOptions });
+}>({ ...BaseLevelTwo.defaults });
 
 // Because 'required' is already provided, this needs no argument
 new BaseLevelTwo();
@@ -87,7 +87,7 @@ expectType<string>(baseLevelTwo.options.required);
 // @ts-expect-error unknown properties cannot be used, see #31
 baseLevelTwo.unknown;
 
-const BaseLevelThree = BaseLevelTwo.defaults({
+const BaseLevelThree = BaseLevelTwo.withDefaults({
   defaultThree: ["a", "b", "c"],
 });
 
@@ -96,7 +96,7 @@ expectType<{
   defaultTwo: number;
   defaultThree: string[];
   required: string;
-}>({ ...BaseLevelThree.defaultOptions });
+}>({ ...BaseLevelThree.defaults });
 
 // Because 'required' is already provided, this needs no argument
 new BaseLevelThree();
@@ -121,7 +121,7 @@ expectType<string>(baseLevelThree.options.required);
 // @ts-expect-error unknown properties cannot be used, see #31
 baseLevelThree.unknown;
 
-const BaseWithVoidPlugin = Base.plugin([voidPlugin]);
+const BaseWithVoidPlugin = Base.withPlugins([voidPlugin]);
 const baseWithVoidPlugin = new BaseWithVoidPlugin({
   required: "1.2.3",
 });
@@ -129,7 +129,7 @@ const baseWithVoidPlugin = new BaseWithVoidPlugin({
 // @ts-expect-error unknown properties cannot be used, see #31
 baseWithVoidPlugin.unknown;
 
-const BaseWithFooAndBarPlugins = Base.plugin([barPlugin, fooPlugin]);
+const BaseWithFooAndBarPlugins = Base.withPlugins([barPlugin, fooPlugin]);
 const baseWithFooAndBarPlugins = new BaseWithFooAndBarPlugins({
   required: "1.2.3",
 });
@@ -140,7 +140,7 @@ expectType<string>(baseWithFooAndBarPlugins.bar);
 // @ts-expect-error unknown properties cannot be used, see #31
 baseWithFooAndBarPlugins.unknown;
 
-const BaseWithVoidAndNonVoidPlugins = Base.plugin([
+const BaseWithVoidAndNonVoidPlugins = Base.withPlugins([
   barPlugin,
   voidPlugin,
   fooPlugin,
@@ -155,15 +155,15 @@ expectType<string>(baseWithVoidAndNonVoidPlugins.bar);
 // @ts-expect-error unknown properties cannot be used, see #31
 baseWithVoidAndNonVoidPlugins.unknown;
 
-const BaseWithOptionsPlugin = Base.plugin([withOptionsPlugin]);
+const BaseWithOptionsPlugin = Base.withPlugins([withOptionsPlugin]);
 const baseWithOptionsPlugin = new BaseWithOptionsPlugin({
   required: "1.2.3",
 });
 
 expectType<string>(baseWithOptionsPlugin.getFooOption());
 
-// Test depth limits of `.defaults()` chaining
-const BaseLevelFour = BaseLevelThree.defaults({ defaultFour: 4 });
+// Test depth limits of `.withDefaults()` chaining
+const BaseLevelFour = BaseLevelThree.withDefaults({ defaultFour: 4 });
 
 expectType<{
   required: string;
@@ -171,12 +171,12 @@ expectType<{
   defaultTwo: number;
   defaultThree: string[];
   defaultFour: number;
-}>({ ...BaseLevelFour.defaultOptions });
+}>({ ...BaseLevelFour.defaults });
 
 const baseLevelFour = new BaseLevelFour();
 
 // See the node on static defaults in index.d.ts for why defaultFour is missing
-// .options from .defaults() is only supported until a depth of 4
+// .options from .withDefaults() is only supported until a depth of 4
 expectType<{
   required: string;
   defaultOne: string;
@@ -190,14 +190,14 @@ expectType<{
   defaultTwo: number;
   defaultThree: string[];
   defaultFour: number;
-  // @ts-expect-error - .options from .defaults() is only supported until a depth of 4
+  // @ts-expect-error - .options from .withDefaults() is only supported until a depth of 4
 }>({ ...baseLevelFour.options });
 
-const BaseWithChainedDefaultsAndPlugins = Base.defaults({
+const BaseWithChainedDefaultsAndPlugins = Base.withDefaults({
   defaultOne: "value",
 })
-  .plugin([fooPlugin])
-  .defaults({
+  .withPlugins([fooPlugin])
+  .withDefaults({
     defaultTwo: 0,
   });
 
@@ -209,15 +209,15 @@ const baseWithChainedDefaultsAndPlugins = new BaseWithChainedDefaultsAndPlugins(
 
 expectType<string>(baseWithChainedDefaultsAndPlugins.foo);
 
-const BaseWithManyChainedDefaultsAndPlugins = Base.defaults({
+const BaseWithManyChainedDefaultsAndPlugins = Base.withDefaults({
   defaultOne: "value",
 })
-  .plugin([fooPlugin, barPlugin, voidPlugin])
-  .defaults({
+  .withPlugins([fooPlugin, barPlugin, voidPlugin])
+  .withDefaults({
     defaultTwo: 0,
   })
-  .plugin([withOptionsPlugin])
-  .defaults({
+  .withPlugins([withOptionsPlugin])
+  .withDefaults({
     defaultThree: ["a", "b", "c"],
   });
 
@@ -225,7 +225,7 @@ expectType<{
   defaultOne: string;
   defaultTwo: number;
   defaultThree: string[];
-}>({ ...BaseWithManyChainedDefaultsAndPlugins.defaultOptions });
+}>({ ...BaseWithManyChainedDefaultsAndPlugins.defaults });
 
 const baseWithManyChainedDefaultsAndPlugins =
   new BaseWithManyChainedDefaultsAndPlugins({

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -33,7 +33,7 @@ new BaseWithEmptyDefaults();
 // @ts-expect-error
 new BaseWithEmptyDefaults({});
 
-const BaseLevelOne = Base.plugin(fooPlugin).defaults({
+const BaseLevelOne = Base.plugin([fooPlugin]).defaults({
   defaultOne: "value",
   required: "1.2.3",
 });
@@ -121,7 +121,7 @@ expectType<string>(baseLevelThree.options.required);
 // @ts-expect-error unknown properties cannot be used, see #31
 baseLevelThree.unknown;
 
-const BaseWithVoidPlugin = Base.plugin(voidPlugin);
+const BaseWithVoidPlugin = Base.plugin([voidPlugin]);
 const baseWithVoidPlugin = new BaseWithVoidPlugin({
   required: "1.2.3",
 });
@@ -129,7 +129,7 @@ const baseWithVoidPlugin = new BaseWithVoidPlugin({
 // @ts-expect-error unknown properties cannot be used, see #31
 baseWithVoidPlugin.unknown;
 
-const BaseWithFooAndBarPlugins = Base.plugin(barPlugin, fooPlugin);
+const BaseWithFooAndBarPlugins = Base.plugin([barPlugin, fooPlugin]);
 const baseWithFooAndBarPlugins = new BaseWithFooAndBarPlugins({
   required: "1.2.3",
 });
@@ -140,11 +140,11 @@ expectType<string>(baseWithFooAndBarPlugins.bar);
 // @ts-expect-error unknown properties cannot be used, see #31
 baseWithFooAndBarPlugins.unknown;
 
-const BaseWithVoidAndNonVoidPlugins = Base.plugin(
+const BaseWithVoidAndNonVoidPlugins = Base.plugin([
   barPlugin,
   voidPlugin,
-  fooPlugin
-);
+  fooPlugin,
+]);
 const baseWithVoidAndNonVoidPlugins = new BaseWithVoidAndNonVoidPlugins({
   required: "1.2.3",
 });
@@ -155,7 +155,7 @@ expectType<string>(baseWithVoidAndNonVoidPlugins.bar);
 // @ts-expect-error unknown properties cannot be used, see #31
 baseWithVoidAndNonVoidPlugins.unknown;
 
-const BaseWithOptionsPlugin = Base.plugin(withOptionsPlugin);
+const BaseWithOptionsPlugin = Base.plugin([withOptionsPlugin]);
 const baseWithOptionsPlugin = new BaseWithOptionsPlugin({
   required: "1.2.3",
 });
@@ -196,7 +196,7 @@ expectType<{
 const BaseWithChainedDefaultsAndPlugins = Base.defaults({
   defaultOne: "value",
 })
-  .plugin(fooPlugin)
+  .plugin([fooPlugin])
   .defaults({
     defaultTwo: 0,
   });
@@ -212,11 +212,11 @@ expectType<string>(baseWithChainedDefaultsAndPlugins.foo);
 const BaseWithManyChainedDefaultsAndPlugins = Base.defaults({
   defaultOne: "value",
 })
-  .plugin(fooPlugin, barPlugin, voidPlugin)
+  .plugin([fooPlugin, barPlugin, voidPlugin])
   .defaults({
     defaultTwo: 0,
   })
-  .plugin(withOptionsPlugin)
+  .plugin([withOptionsPlugin])
   .defaults({
     defaultThree: ["a", "b", "c"],
   });

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,5 @@
 import { expectType } from "tsd";
-import { Base } from "./index.js";
+import { Base, Plugin } from "./index.js";
 
 import { fooPlugin } from "./plugins/foo/index.js";
 import { barPlugin } from "./plugins/bar/index.js";
@@ -32,6 +32,8 @@ new BaseWithEmptyDefaults();
 // 'required' is missing and should still be required
 // @ts-expect-error
 new BaseWithEmptyDefaults({});
+
+expectType<Plugin[]>(Base.plugins);
 
 const BaseLevelOne = Base.withPlugins([fooPlugin]).withDefaults({
   defaultOne: "value",

--- a/test.js
+++ b/test.js
@@ -6,25 +6,25 @@ import { fooPlugin } from "./plugins/foo/index.js";
 import { barPlugin } from "./plugins/bar/index.js";
 import { voidPlugin } from "./plugins/void/index.js";
 
-test(".plugin(fooPlugin)", () => {
-  const FooTest = Base.plugin(fooPlugin);
+test(".plugin([fooPlugin])", () => {
+  const FooTest = Base.plugin([fooPlugin]);
   const fooTest = new FooTest();
   assert.equal(fooTest.foo, "foo");
 });
-test(".plugin(fooPlugin, barPlugin)", () => {
-  const FooBarTest = Base.plugin(fooPlugin, barPlugin);
+test(".plugin([fooPlugin, barPlugin])", () => {
+  const FooBarTest = Base.plugin([fooPlugin, barPlugin]);
   const fooBarTest = new FooBarTest();
   assert.equal(fooBarTest.foo, "foo");
   assert.equal(fooBarTest.bar, "bar");
 });
-test(".plugin(fooPlugin, barPlugin, voidPlugin)", () => {
-  const FooBarTest = Base.plugin(fooPlugin, barPlugin, voidPlugin);
+test(".plugin([fooPlugin, barPlugin, voidPlugin])", () => {
+  const FooBarTest = Base.plugin([fooPlugin, barPlugin, voidPlugin]);
   const fooBarTest = new FooBarTest();
   assert.equal(fooBarTest.foo, "foo");
   assert.equal(fooBarTest.bar, "bar");
 });
-test(".plugin(fooPlugin).plugin(barPlugin)", () => {
-  const FooBarTest = Base.plugin(fooPlugin).plugin(barPlugin);
+test(".plugin([fooPlugin]).plugin(barPlugin)", () => {
+  const FooBarTest = Base.plugin([fooPlugin]).plugin([barPlugin]);
   const fooBarTest = new FooBarTest();
   assert.equal(fooBarTest.foo, "foo");
   assert.equal(fooBarTest.bar, "bar");
@@ -61,12 +61,12 @@ test(".defaults({foo: 'bar', baz: 'daz' })", () => {
 });
 
 test(".plugin().defaults()", () => {
-  const BaseWithPluginAndDefaults = Base.plugin(fooPlugin).defaults({
+  const BaseWithPluginAndDefaults = Base.plugin([fooPlugin]).defaults({
     baz: "daz",
   });
   const BaseWithDefaultsAndPlugin = Base.defaults({
     baz: "daz",
-  }).plugin(fooPlugin);
+  }).plugin([fooPlugin]);
 
   const instance1 = new BaseWithPluginAndDefaults();
   const instance2 = new BaseWithDefaultsAndPlugin();

--- a/test.js
+++ b/test.js
@@ -6,52 +6,54 @@ import { fooPlugin } from "./plugins/foo/index.js";
 import { barPlugin } from "./plugins/bar/index.js";
 import { voidPlugin } from "./plugins/void/index.js";
 
-test(".plugin([fooPlugin])", () => {
-  const FooTest = Base.plugin([fooPlugin]);
+test(".withPlugins([fooPlugin])", () => {
+  const FooTest = Base.withPlugins([fooPlugin]);
   const fooTest = new FooTest();
   assert.equal(fooTest.foo, "foo");
 });
-test(".plugin([fooPlugin, barPlugin])", () => {
-  const FooBarTest = Base.plugin([fooPlugin, barPlugin]);
+test(".withPlugins([fooPlugin, barPlugin])", () => {
+  const FooBarTest = Base.withPlugins([fooPlugin, barPlugin]);
   const fooBarTest = new FooBarTest();
   assert.equal(fooBarTest.foo, "foo");
   assert.equal(fooBarTest.bar, "bar");
 });
-test(".plugin([fooPlugin, barPlugin, voidPlugin])", () => {
-  const FooBarTest = Base.plugin([fooPlugin, barPlugin, voidPlugin]);
+test(".withPlugins([fooPlugin, barPlugin, voidPlugin])", () => {
+  const FooBarTest = Base.withPlugins([fooPlugin, barPlugin, voidPlugin]);
   const fooBarTest = new FooBarTest();
   assert.equal(fooBarTest.foo, "foo");
   assert.equal(fooBarTest.bar, "bar");
 });
-test(".plugin([fooPlugin]).plugin(barPlugin)", () => {
-  const FooBarTest = Base.plugin([fooPlugin]).plugin([barPlugin]);
+test(".withPlugins([fooPlugin]).withPlugins(barPlugin)", () => {
+  const FooBarTest = Base.withPlugins([fooPlugin]).withPlugins([barPlugin]);
   const fooBarTest = new FooBarTest();
   assert.equal(fooBarTest.foo, "foo");
   assert.equal(fooBarTest.bar, "bar");
 });
-test(".defaults({foo: 'bar'})", () => {
-  const BaseWithDefaults = Base.defaults({ foo: "bar" });
+test(".withDefaults({foo: 'bar'})", () => {
+  const BaseWithDefaults = Base.withDefaults({ foo: "bar" });
   const defaultsTest = new BaseWithDefaults();
   const mergedOptionsTest = new BaseWithDefaults({ baz: "daz" });
-  assert.equal(BaseWithDefaults.defaultOptions, { foo: "bar" });
+  assert.equal(BaseWithDefaults.defaults, { foo: "bar" });
   assert.equal(defaultsTest.options, { foo: "bar" });
   assert.equal(mergedOptionsTest.options, { foo: "bar", baz: "daz" });
 });
-test(".defaults({one: 1}).defaults({two: 2})", () => {
-  const BaseWithDefaults = Base.defaults({ one: 1 }).defaults({ two: 2 });
+test(".withDefaults({one: 1}).withDefaults({two: 2})", () => {
+  const BaseWithDefaults = Base.withDefaults({ one: 1 }).withDefaults({
+    two: 2,
+  });
   const defaultsTest = new BaseWithDefaults();
   const mergedOptionsTest = new BaseWithDefaults({ three: 3 });
   assert.equal(defaultsTest.options, { one: 1, two: 2 });
   assert.equal(mergedOptionsTest.options, { one: 1, two: 2, three: 3 });
 });
 
-test(".defaults({foo: 'bar', baz: 'daz' })", () => {
-  const BaseWithDefaults = Base.defaults({ foo: "bar" }).defaults({
+test(".withDefaults({foo: 'bar', baz: 'daz' })", () => {
+  const BaseWithDefaults = Base.withDefaults({ foo: "bar" }).withDefaults({
     baz: "daz",
   });
   const defaultsTest = new BaseWithDefaults();
   const mergedOptionsTest = new BaseWithDefaults({ faz: "boo" });
-  assert.equal(BaseWithDefaults.defaultOptions, { foo: "bar", baz: "daz" });
+  assert.equal(BaseWithDefaults.defaults, { foo: "bar", baz: "daz" });
   assert.equal(defaultsTest.options, { foo: "bar", baz: "daz" });
   assert.equal(mergedOptionsTest.options, {
     foo: "bar",
@@ -60,13 +62,13 @@ test(".defaults({foo: 'bar', baz: 'daz' })", () => {
   });
 });
 
-test(".plugin().defaults()", () => {
-  const BaseWithPluginAndDefaults = Base.plugin([fooPlugin]).defaults({
+test(".withPlugins().withDefaults()", () => {
+  const BaseWithPluginAndDefaults = Base.withPlugins([fooPlugin]).withDefaults({
     baz: "daz",
   });
-  const BaseWithDefaultsAndPlugin = Base.defaults({
+  const BaseWithDefaultsAndPlugin = Base.withDefaults({
     baz: "daz",
-  }).plugin([fooPlugin]);
+  }).withPlugins([fooPlugin]);
 
   const instance1 = new BaseWithPluginAndDefaults();
   const instance2 = new BaseWithDefaultsAndPlugin();

--- a/test.js
+++ b/test.js
@@ -10,24 +10,28 @@ test(".withPlugins([fooPlugin])", () => {
   const FooTest = Base.withPlugins([fooPlugin]);
   const fooTest = new FooTest();
   assert.equal(fooTest.foo, "foo");
+  assert.equal(FooTest.plugins, [fooPlugin]);
 });
 test(".withPlugins([fooPlugin, barPlugin])", () => {
   const FooBarTest = Base.withPlugins([fooPlugin, barPlugin]);
   const fooBarTest = new FooBarTest();
   assert.equal(fooBarTest.foo, "foo");
   assert.equal(fooBarTest.bar, "bar");
+  assert.equal(FooBarTest.plugins, [fooPlugin, barPlugin]);
 });
 test(".withPlugins([fooPlugin, barPlugin, voidPlugin])", () => {
-  const FooBarTest = Base.withPlugins([fooPlugin, barPlugin, voidPlugin]);
-  const fooBarTest = new FooBarTest();
-  assert.equal(fooBarTest.foo, "foo");
-  assert.equal(fooBarTest.bar, "bar");
+  const FooBarTestVoid = Base.withPlugins([fooPlugin, barPlugin, voidPlugin]);
+  const fooBarTestVoid = new FooBarTestVoid();
+  assert.equal(fooBarTestVoid.foo, "foo");
+  assert.equal(fooBarTestVoid.bar, "bar");
+  assert.equal(FooBarTestVoid.plugins, [fooPlugin, barPlugin, voidPlugin]);
 });
 test(".withPlugins([fooPlugin]).withPlugins(barPlugin)", () => {
   const FooBarTest = Base.withPlugins([fooPlugin]).withPlugins([barPlugin]);
   const fooBarTest = new FooBarTest();
   assert.equal(fooBarTest.foo, "foo");
   assert.equal(fooBarTest.bar, "bar");
+  assert.equal(FooBarTest.plugins, [fooPlugin, barPlugin]);
 });
 test(".withDefaults({foo: 'bar'})", () => {
   const BaseWithDefaults = Base.withDefaults({ foo: "bar" });
@@ -36,6 +40,7 @@ test(".withDefaults({foo: 'bar'})", () => {
   assert.equal(BaseWithDefaults.defaults, { foo: "bar" });
   assert.equal(defaultsTest.options, { foo: "bar" });
   assert.equal(mergedOptionsTest.options, { foo: "bar", baz: "daz" });
+  assert.equal(BaseWithDefaults.defaults, { foo: "bar" });
 });
 test(".withDefaults({one: 1}).withDefaults({two: 2})", () => {
   const BaseWithDefaults = Base.withDefaults({ one: 1 }).withDefaults({
@@ -45,6 +50,7 @@ test(".withDefaults({one: 1}).withDefaults({two: 2})", () => {
   const mergedOptionsTest = new BaseWithDefaults({ three: 3 });
   assert.equal(defaultsTest.options, { one: 1, two: 2 });
   assert.equal(mergedOptionsTest.options, { one: 1, two: 2, three: 3 });
+  assert.equal(BaseWithDefaults.defaults, { one: 1, two: 2 });
 });
 
 test(".withDefaults({foo: 'bar', baz: 'daz' })", () => {
@@ -60,6 +66,7 @@ test(".withDefaults({foo: 'bar', baz: 'daz' })", () => {
     baz: "daz",
     faz: "boo",
   });
+  assert.equal(BaseWithDefaults.defaults, { foo: "bar", baz: "daz" });
 });
 
 test(".withPlugins().withDefaults()", () => {
@@ -77,6 +84,12 @@ test(".withPlugins().withDefaults()", () => {
   assert.equal(instance1.options, { baz: "daz" });
   assert.equal(instance2.foo, "foo");
   assert.equal(instance2.options, { baz: "daz" });
+
+  assert.equal(BaseWithPluginAndDefaults.defaults, { baz: "daz" });
+  assert.equal(BaseWithDefaultsAndPlugin.defaults, { baz: "daz" });
+
+  assert.equal(BaseWithPluginAndDefaults.plugins, [fooPlugin]);
+  assert.equal(BaseWithDefaultsAndPlugin.plugins, [fooPlugin]);
 });
 
 test.run();


### PR DESCRIPTION
closes #62

BREAKING CHANGE: `Base.plugin()` now only accepts a single argument which has to be an array of plugin functions
